### PR TITLE
Fix achievement trigger

### DIFF
--- a/CTCImmuneGame.html
+++ b/CTCImmuneGame.html
@@ -713,10 +713,10 @@
 
           // Achievement check moved inside correct answer block
           gameData.achievements.forEach(ach => {
-              if (!unlockedAchievements.find(ua => ua.id === ach.id) && ach.condition(role, levelIndex, false)) {
+              if (!unlockedAchievements.find(ua => ua.id === ach.id) && ach.condition(role, levelIndex + 1, false)) {
                   setUnlockedAchievements(prev => [...prev, ach]);
-                  setCurrentToast(ach); 
-                  setNarratorText(gameData.narratorComments.achievement); 
+                  setCurrentToast(ach);
+                  setNarratorText(gameData.narratorComments.achievement);
               }
           });
 


### PR DESCRIPTION
## Summary
- adjust level value passed to achievement condition so early badges unlock correctly

## Testing
- `tidy -e CTCImmuneGame.html`

------
https://chatgpt.com/codex/tasks/task_e_6840f198093c832191cac73506d2b78e